### PR TITLE
main.cpp: fix build with gcc-4.9

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,9 +363,9 @@ void CVisualizationMatrix::RenderTo(GLuint shader, GLuint effect_fb)
       {
         double logotimer = std::chrono::duration<double>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
         float delta = static_cast<float>(logotimer - m_lastAlbumChange)*0.6f;
-        GLfloat r = std::max(sin(delta),0.0f)*0.7f;
-        GLfloat g = std::max(sin(delta - 1.0f),0.0f)*0.7f;
-        GLfloat b = std::max(sin(delta - 2.0f),0.0f)*0.7f;
+        GLfloat r = std::max(static_cast<float>(sin(delta)),0.0f)*0.7f;
+        GLfloat g = std::max(static_cast<float>(sin(delta - 1.0f)),0.0f)*0.7f;
+        GLfloat b = std::max(static_cast<float>(sin(delta - 2.0f)),0.0f)*0.7f;
         glUniform3f(m_attrAlbumRGBLoc, r, g, b);
         if (m_lastAlbumChange == 0.0)
         {


### PR DESCRIPTION
Fixes build error:

src/main.cpp:366:45: error: no matching function for call to 'max(double, float)'
         GLfloat r = std::max(sin(delta),0.0f)*0.7f;