### PR TITLE
[Matrix] final Matrix change to correct test builds and take as Version 19.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 
 before_install:
   - if [[ $DEBIAN_BUILD != true ]] && [[ $TRAVIS_OS_NAME == linux ]]; then sudo apt-get install -y libgl1-mesa-dev; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
 
 #
@@ -41,7 +41,7 @@ before_install:
 #
 before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
-  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a [Kodi](https://kodi.tv) visualization addon.
 The following instructions assume you will have built Kodi already in the `kodi-build` directory 
 suggested by the README.
 
-1. `git clone --branch master https://github.com/xbmc/xbmc.git`
+1. `git clone --branch Matrix https://github.com/xbmc/xbmc.git`
 2. `git clone --branch Matrix https://github.com/xbmc/visualization.matrix.git`
 3. `cd visualization.matrix && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=visualization.matrix -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
 
 build_script:
   - cd ..
-  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
+  - git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git
   - cd %app_id%
   - mkdir build
   - cd build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
 
     - script: |
         cd ..
-        git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git kodi
+        git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git kodi
         cd $(Build.SourcesDirectory)
         mkdir build
         cd build

--- a/visualization.matrix/addon.xml.in
+++ b/visualization.matrix/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.matrix"
-  version="1.0.1"
+  version="19.0.0"
   name="Matrix"
   provider-name="Sarbes">
   <requires>@ADDON_DEPENDS@</requires>

--- a/visualization.matrix/changelog.txt
+++ b/visualization.matrix/changelog.txt
@@ -1,3 +1,11 @@
+19.0.0
+- Update dependency kissfft to version 131.1.0 (16. Feb. 2021)
+- Update dependency stb_image.h to version 2.27 (11. Jul. 2021)
+- Language translation updates by Weblate
+- Change test builds to released 'Kodi 19 Matrix'
+- Increase version to 19.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
 1.0.1
 - Fixed German translation (did not work at all before)
 1.0.0
@@ -12,7 +20,7 @@
 - Fix Debian build code
 - Add license file, add license and source URL to addon.xml
 0.4.2
-- Pre-Relese version for Kodi Matrix
+- Pre-Release version for Kodi Matrix
 0.2.0
 - Major features done
 0.0.1


### PR DESCRIPTION
This change the builds to final released Kodi Matrix.

Further is the version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.